### PR TITLE
settings: make explanation string configurable

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -29,3 +29,5 @@ replayed = [
   "Revenge of the OTP",
   "The \"OT\" stands for \"One Time\""
 ]
+
+explanation = "_The OTP has been consumed._"

--- a/src/main.rs
+++ b/src/main.rs
@@ -39,6 +39,7 @@ struct ValidatorApp {
     slack_signing_secret: String,
     success: Vec<String>,
     replayed: Vec<String>,
+    explanation: String,
 }
 
 #[derive(Debug, Deserialize)]
@@ -241,7 +242,7 @@ fn handle_req(
                                         "elements": [
                                             {
                                                 "type": "mrkdwn",
-                                                "text": "_The OTP has been consumed._"
+                                                "text": &s.explanation
                                             }
                                         ]
                                     }
@@ -307,6 +308,7 @@ fn main() -> Result<(), io::Error> {
         slack_signing_secret: settings.slack.signingsecret,
         success: settings.answers.success,
         replayed: settings.answers.replayed,
+        explanation: settings.answers.explanation
     });
 
     HttpServer::new(move || {

--- a/src/settings.rs
+++ b/src/settings.rs
@@ -49,17 +49,19 @@ impl fmt::Display for OtpValidation {
 pub struct Answer {
     pub success: Vec<String>,
     pub replayed: Vec<String>,
+    pub explanation: String
 }
 
 impl fmt::Display for Answer {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(
             f,
-            "Answer (success: {:?}, replayed: {:?})",
-            self.success, self.replayed
+            "Answer (success: {:?}, replayed: {:?}, explanation: {:?})",
+            self.success, self.replayed, self.explanation
         )
     }
 }
+
 
 #[derive(Debug, Deserialize, Clone)]
 pub struct Settings {
@@ -99,6 +101,7 @@ impl Settings {
 
         s.set_default("answers.success", vec!["Success"])?;
         s.set_default("answers.replayed", vec!["Replayed"])?;
+        s.set_default("answers.explanation", "_The OTP has been consumed._")?;
 
         s.merge(File::with_name(&file))?;
 


### PR DESCRIPTION
The idea is to make the static explanation message shown by yubotp configurable from the .toml file. 

This is untested, but at least it builds :)